### PR TITLE
fix[Tooltip]: mount the tooltip to the body

### DIFF
--- a/pandemic-ui/src/css/components.css
+++ b/pandemic-ui/src/css/components.css
@@ -149,16 +149,14 @@ body.modal-open {
 
 /* --- Tooltip --- */
 .Tooltip-container {
-  position: relative;
+  display: inline-block;
 }
 
 .Tooltip-text {
-  position: absolute;
   display: block;
-  opacity: 0;
-  visibility: hidden;
+  opacity: 1;
+  visibility: visible;
   transition: opacity 0.2s, visibility 0.2s;
-  z-index: 1000;
   background-color: rgba(0, 0, 0, 0.8);
   color: white;
   padding: 8px 12px;
@@ -167,35 +165,7 @@ body.modal-open {
   min-width: fit-content;
   width: max-content;
   max-width: 200px;
-}
-
-/* Position-specific styles */
-.Tooltip-top {
-  bottom: 100%;
-  left: 50%;
-  transform: translateX(-50%);
-  margin-bottom: 8px;
-}
-
-.Tooltip-bottom {
-  top: 100%;
-  left: 50%;
-  transform: translateX(-50%);
-  margin-top: 8px;
-}
-
-.Tooltip-left {
-  top: 50%;
-  right: 100%;
-  transform: translateY(-50%);
-  margin-right: 8px;
-}
-
-.Tooltip-right {
-  top: 50%;
-  left: 100%;
-  transform: translateY(-50%);
-  margin-left: 8px;
+  pointer-events: none;
 }
 
 /* Position-specific arrows */
@@ -241,9 +211,4 @@ body.modal-open {
   border-width: 5px;
   border-style: solid;
   border-color: transparent rgba(0, 0, 0, 0.8) transparent transparent;
-}
-
-.Tooltip-container:hover .Tooltip-text {
-  opacity: 1;
-  visibility: visible;
 }

--- a/pandemic-ui/src/js/components/Tooltip.tsx
+++ b/pandemic-ui/src/js/components/Tooltip.tsx
@@ -1,19 +1,111 @@
-import { PropsWithChildren, ReactNode } from 'react';
+import { CSSProperties, PropsWithChildren, ReactNode, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 
 type TooltipPosition = 'left' | 'right' | 'bottom' | 'top';
+
+
+const calculateStyles = (el: HTMLElement | null, position: TooltipPosition) => {
+  if (!el) return;
+
+  const rect = el.getBoundingClientRect();
+  const scrollX = window.pageXOffset || document.documentElement.scrollLeft;
+  const scrollY = window.pageYOffset || document.documentElement.scrollTop;
+
+  const style: CSSProperties = {
+    position: 'absolute',
+    zIndex: 1000,
+  };
+
+  switch (position) {
+    case 'top':
+      style.left = rect.left + scrollX + rect.width / 2;
+      style.top = rect.top + scrollY - 8;
+      style.transform = 'translate(-50%, -100%)';
+      break;
+    case 'bottom':
+      style.left = rect.left + scrollX + rect.width / 2;
+      style.top = rect.bottom + scrollY + 8;
+      style.transform = 'translateX(-50%)';
+      break;
+    case 'left':
+      style.left = rect.left + scrollX - 8;
+      style.top = rect.top + scrollY + rect.height / 2;
+      style.transform = 'translate(-100%, -50%)';
+      break;
+    case 'right':
+      style.left = rect.right + scrollX + 8;
+      style.top = rect.top + scrollY + rect.height / 2;
+      style.transform = 'translateY(-50%)';
+      break;
+  }
+
+  return style;
+};
 
 export const Tooltip = ({
   position = 'top',
   children,
   text,
 }: PropsWithChildren<{ text: ReactNode; position?: TooltipPosition }>) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [isVisible, setIsVisible] = useState(false);
+  const [tooltipStyle, setTooltipStyle] = useState<CSSProperties>({});
+
+
+  useEffect(() => {
+    if (isVisible) {
+      const style = calculateStyles(containerRef.current, position);
+      if (style)  setTooltipStyle(style);
+
+
+      const handleScroll = () => {
+        const scrolledStyles = calculateStyles(containerRef.current, position);
+        if (scrolledStyles) setTooltipStyle(scrolledStyles);
+      };
+      const handleResize = () => {
+        const resizedStyles = calculateStyles(containerRef.current, position);
+        if (resizedStyles) setTooltipStyle(resizedStyles);
+      };
+
+      window.addEventListener('scroll', handleScroll);
+      window.addEventListener('resize', handleResize);
+
+      return () => {
+        window.removeEventListener('scroll', handleScroll);
+        window.removeEventListener('resize', handleResize);
+      };
+    }
+  }, [isVisible, position]);
+
+  const handleMouseEnter = () => {
+    setIsVisible(true);
+  };
+
+  const handleMouseLeave = () => {
+    setIsVisible(false);
+  };
+
   return (
-    <div className="Tooltip-container">
-      {children}
-      <div className={`Tooltip-text Tooltip-${position}`} role="tooltip">
-        {text}
+    <>
+      <div
+        ref={containerRef}
+        className="Tooltip-container"
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+      >
+        {children}
       </div>
-    </div>
+      {isVisible && createPortal(
+        <div
+          className={`Tooltip-text Tooltip-${position}`}
+          role="tooltip"
+          style={tooltipStyle}
+        >
+          {text}
+        </div>,
+        document.body
+      )}
+    </>
   );
 };
 


### PR DESCRIPTION
## Changes Made

### Problem
The tooltip text was previously positioned relative to its container, which could cause z-index issues and positioning problems when the container was inside elements with `overflow: hidden` or complex stacking contexts.

|before|after|
|--|--|
|<img width="543" height="352" alt="before" src="https://github.com/user-attachments/assets/ac8bcb2f-5008-462f-a5f0-548e3d04b202" />|<img width="571" height="393" alt="after" src="https://github.com/user-attachments/assets/507938b7-c6c6-4679-b48c-ba72eb4558ce" />|

### Solution
- **Portal Implementation**: Used React's `createPortal` to mount tooltip text directly to `document.body`
- **Dynamic Positioning**: Added logic to calculate exact positioning using `getBoundingClientRect()`
- **Event Handling**: Implemented proper mouse enter/leave handlers with scroll/resize listeners
- **CSS Updates**: Simplified positioning styles since tooltip is now portaled to document root

### Key Benefits
- ✅ Tooltip appears above all other content without z-index conflicts
- ✅ Maintains correct position during scrolling and window resizing  
- ✅ Independent of parent container's overflow/positioning context
- ✅ Preserves all existing visual styling and arrow indicators

### Files Changed
- `pandemic-ui/src/js/components/Tooltip.tsx` - Added portal logic and positioning
- `pandemic-ui/src/css/components.css` - Updated CSS for portal-based approach

### Testing
- No linting errors
- Maintains backward compatibility with existing tooltip usage